### PR TITLE
Currently you can only record an audio. I would like to also allow the capabilit (zenflow)

### DIFF
--- a/.zenflow/tasks/currently-you-can-only-record-an-8bbe/plan.md
+++ b/.zenflow/tasks/currently-you-can-only-record-an-8bbe/plan.md
@@ -1,0 +1,17 @@
+# Drag-and-Drop Audio File Upload
+
+## Summary
+Add drag-and-drop audio file upload to the home page. Dropped files are streamed into OPFS with a progress bar, a project is auto-created, and the user is taken to the Recorder UI in playback-only mode.
+
+### [x] Step: Update plan.md
+
+### [ ] Step: Add drag-and-drop + upload to App.tsx
+- Full-page drag overlay when `view === "list"`
+- Stream file chunks to OPFS via `getWritableStream`, tracking progress
+- Show progress bar + message (mirroring transcription progress UI)
+- Create project, save with `audioFile`, navigate to editor
+
+### [ ] Step: Recorder playback-only for uploaded files
+- Recorder already enters `recorded` state when `project.audioFile` is set (no recording controls shown)
+- Update "Recording complete" label to be neutral ("Audio ready") when applicable
+- Verify end-to-end: drop → progress → editor → transcribe

--- a/.zenflow/tasks/currently-you-can-only-record-an-8bbe/plan.md
+++ b/.zenflow/tasks/currently-you-can-only-record-an-8bbe/plan.md
@@ -5,13 +5,13 @@ Add drag-and-drop audio file upload to the home page. Dropped files are streamed
 
 ### [x] Step: Update plan.md
 
-### [ ] Step: Add drag-and-drop + upload to App.tsx
+### [x] Step: Add drag-and-drop + upload to App.tsx
 - Full-page drag overlay when `view === "list"`
 - Stream file chunks to OPFS via `getWritableStream`, tracking progress
 - Show progress bar + message (mirroring transcription progress UI)
 - Create project, save with `audioFile`, navigate to editor
 
-### [ ] Step: Recorder playback-only for uploaded files
+### [x] Step: Recorder playback-only for uploaded files
 - Recorder already enters `recorded` state when `project.audioFile` is set (no recording controls shown)
 - Update "Recording complete" label to be neutral ("Audio ready") when applicable
 - Verify end-to-end: drop → progress → editor → transcribe

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TextCast
 
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/sirmews/textcast?utm_source=oss&utm_medium=github&utm_campaign=sirmews%2Ftextcast&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
+
 Edit audio by editing text. A local-first, browser-based audio editor for podcasters.
 
 ## Features

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -234,7 +234,7 @@ function App() {
 
       <main className="max-w-4xl mx-auto px-6 py-8">
         {view === "list" ? (
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: drop zone requires drag event handlers */}
+          // biome-ignore lint/a11y/noStaticElementInteractions: drop zone requires drag event handlers
           <div
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { FileAudio, HardDrive, Mic, Plus } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { FileAudio, HardDrive, Mic, Plus, Upload } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { storage } from "@/lib/storage";
 import { ModeToggle } from "./components/mode-toggle";
@@ -14,11 +14,22 @@ import {
 } from "./lib/db";
 import type { Project } from "./types";
 
+function isAudioFile(file: File) {
+  return (
+    file.type.startsWith("audio/") ||
+    /\.(mp3|wav|ogg|flac|m4a|webm|aac|opus|wma)$/i.test(file.name)
+  );
+}
+
 function App() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [currentProject, setCurrentProject] = useState<Project | null>(null);
   const [view, setView] = useState<"list" | "editor">("list");
   const [isClearing, setIsClearing] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
+  const [uploadMessage, setUploadMessage] = useState("");
+  const dragCounterRef = useRef(0);
 
   const loadProjects = useCallback(async () => {
     const projectList = await getProjects();
@@ -47,14 +58,13 @@ function App() {
 
   async function handleSaveProject(project: Project) {
     await saveProject(project);
-    setCurrentProject(project); // Update local state so Recorder receives new props
+    setCurrentProject(project);
     loadProjects();
   }
 
   async function handleDeleteProject(id: string) {
     const projectToDelete = projects.find((p) => p.id === id);
 
-    // Clean up OPFS storage
     if (projectToDelete?.audioFile) {
       const filename1 = projectToDelete.audioFile.opfsFilename;
       const filename2 = `project-${id}-raw.pcm`;
@@ -99,6 +109,92 @@ function App() {
     }
   }
 
+  const handleFileUpload = useCallback(
+    async (file: File) => {
+      const name = file.name.replace(/\.[^.]+$/, "");
+      const project = await createProject(name);
+
+      const ext = file.name.split(".").pop() || "audio";
+      const opfsFilename = `project-${project.id}.${ext}`;
+
+      setUploadProgress(0);
+      setUploadMessage(`Storing "${file.name}"...`);
+
+      try {
+        const writable = await storage.getWritableStream(opfsFilename);
+        const reader = file.stream().getReader();
+        let loaded = 0;
+        const total = file.size;
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          await writable.write(value);
+          loaded += value.byteLength;
+          setUploadProgress(Math.round((loaded / total) * 100));
+        }
+        await writable.close();
+
+        const projectWithAudio: Project = {
+          ...project,
+          audioFile: {
+            name: file.name,
+            duration: 0,
+            opfsFilename,
+          },
+          updatedAt: Date.now(),
+        };
+
+        await saveProject(projectWithAudio);
+        setCurrentProject(projectWithAudio);
+        await loadProjects();
+        setView("editor");
+      } catch (err) {
+        console.error("Failed to store audio file:", err);
+        await deleteProject(project.id);
+        await loadProjects();
+      } finally {
+        setUploadProgress(null);
+        setUploadMessage("");
+      }
+    },
+    [loadProjects],
+  );
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    dragCounterRef.current++;
+    if (e.dataTransfer.types.includes("Files")) {
+      setIsDragging(true);
+    }
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) {
+      setIsDragging(false);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent) => {
+      e.preventDefault();
+      dragCounterRef.current = 0;
+      setIsDragging(false);
+
+      const file = e.dataTransfer.files[0];
+      if (!file || !isAudioFile(file)) return;
+
+      await handleFileUpload(file);
+    },
+    [handleFileUpload],
+  );
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="bg-card border-b border-border px-6 py-4">
@@ -138,7 +234,44 @@ function App() {
 
       <main className="max-w-4xl mx-auto px-6 py-8">
         {view === "list" ? (
-          <div>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: drop zone requires drag event handlers */}
+          <div
+            onDragEnter={handleDragEnter}
+            onDragLeave={handleDragLeave}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            className="relative"
+          >
+            {isDragging && (
+              <div className="absolute inset-0 z-10 flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-primary bg-primary/5 pointer-events-none">
+                <Upload className="w-12 h-12 text-primary mb-3" />
+                <p className="text-lg font-medium text-primary">
+                  Drop audio file to create project
+                </p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  MP3, WAV, OGG, FLAC, M4A, WebM supported
+                </p>
+              </div>
+            )}
+
+            {uploadProgress !== null && (
+              <div className="mb-6 p-6 bg-card border border-border rounded-lg text-center">
+                <Upload className="w-8 h-8 text-primary mx-auto mb-3" />
+                <p className="text-sm font-medium text-foreground mb-3">
+                  {uploadMessage}
+                </p>
+                <div className="w-64 h-2 bg-muted rounded-full mx-auto overflow-hidden">
+                  <div
+                    className="h-full bg-primary transition-all duration-100"
+                    style={{ width: `${uploadProgress}%` }}
+                  />
+                </div>
+                <p className="text-sm text-muted-foreground mt-2">
+                  {uploadProgress}%
+                </p>
+              </div>
+            )}
+
             <div className="mb-6 p-4 bg-muted/50 border border-border rounded-lg">
               <p className="text-sm text-muted-foreground mb-3">
                 <strong className="text-foreground">TextCast</strong>{" "}
@@ -178,19 +311,28 @@ function App() {
             </div>
 
             {projects.length === 0 ? (
-              <div className="text-center py-12 bg-card rounded-lg border border-border">
+              <div className="text-center py-12 bg-card rounded-lg border border-border border-dashed">
                 <FileAudio className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-                <p className="text-muted-foreground mb-4">No projects yet</p>
+                <p className="text-muted-foreground mb-2">No projects yet</p>
+                <p className="text-sm text-muted-foreground mb-4">
+                  Record audio or drop a file anywhere on this page
+                </p>
                 <Button variant="link" onClick={handleNewProject}>
                   Create your first project
                 </Button>
               </div>
             ) : (
-              <ProjectList
-                projects={projects}
-                onSelect={handleSelectProject}
-                onDelete={handleDeleteProject}
-              />
+              <>
+                <ProjectList
+                  projects={projects}
+                  onSelect={handleSelectProject}
+                  onDelete={handleDeleteProject}
+                />
+                <p className="text-xs text-muted-foreground text-center mt-4">
+                  Drop an audio file anywhere on this page to create a new
+                  project
+                </p>
+              </>
             )}
           </div>
         ) : currentProject ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { FileAudio, HardDrive, Mic, Plus, Upload } from "lucide-react";
+import { FileAudio, Github, HardDrive, Mic, Plus, Upload } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { storage } from "@/lib/storage";
@@ -227,6 +227,15 @@ function App() {
               <HardDrive className="w-4 h-4" />
               {isClearing ? "Clearing..." : "Clear AI Models"}
             </Button>
+            <a
+              href="https://github.com/sirmews/textcast"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center rounded-md text-sm font-medium h-9 w-9 text-muted-foreground hover:text-foreground transition-colors"
+              title="View on GitHub"
+            >
+              <Github className="w-4 h-4" />
+            </a>
             <ModeToggle />
           </div>
         </div>

--- a/src/components/recorder/Recorder.tsx
+++ b/src/components/recorder/Recorder.tsx
@@ -445,7 +445,11 @@ export function Recorder({ project, onSave }: RecorderProps) {
                 />
               </div>
               <p className="text-muted-foreground mb-4">
-                {isPreviewPlaying ? "Playing audio..." : "Recording complete"}
+                {isPreviewPlaying
+                  ? "Playing audio..."
+                  : project.audioFile?.opfsFilename?.endsWith(".pcm")
+                    ? "Recording complete"
+                    : "Audio ready"}
               </p>
 
               <div className="flex gap-3 justify-center">

--- a/src/components/recorder/Recorder.tsx
+++ b/src/components/recorder/Recorder.tsx
@@ -146,7 +146,7 @@ export function Recorder({ project, onSave }: RecorderProps) {
               );
               buffer.getChannelData(0).set(floatData);
             } else {
-              // Handle legacy WebM
+              // Handle encoded formats (MP3, WAV, OGG, FLAC, WebM, etc.)
               buffer = await audioContext.decodeAudioData(arrayBuffer);
             }
 
@@ -286,7 +286,7 @@ export function Recorder({ project, onSave }: RecorderProps) {
         ...project,
         audioFile: {
           ...project.audioFile,
-          name: "recording.wav",
+          name: project.audioFile?.name || "recording.wav",
           duration: audioBuffer.duration,
         },
         transcript: {

--- a/src/components/recorder/Recorder.tsx
+++ b/src/components/recorder/Recorder.tsx
@@ -356,6 +356,10 @@ export function Recorder({ project, onSave }: RecorderProps) {
     }
   }
 
+  const effectiveFilename =
+    project.audioFile?.opfsFilename ?? `project-${project.id}-raw.pcm`;
+  const isRecordedPcm = effectiveFilename.endsWith(".pcm");
+
   return (
     <div className="space-y-6">
       {state !== "done" && (
@@ -447,7 +451,7 @@ export function Recorder({ project, onSave }: RecorderProps) {
               <p className="text-muted-foreground mb-4">
                 {isPreviewPlaying
                   ? "Playing audio..."
-                  : project.audioFile?.opfsFilename?.endsWith(".pcm")
+                  : isRecordedPcm
                     ? "Recording complete"
                     : "Audio ready"}
               </p>


### PR DESCRIPTION
Currently you can only record an audio. I would like to also allow the capability of dragging and dropping an audio file on the home page, which automatically creates a project this will store to OPFS, the same storage that the recorder uses. Once the file is effectively uploaded, we just go to the same recording UI but this time there's only playback. The user can then hit the transcribe and play button to continue. During the upload process (that is when you are uploading a file), we should also show a progress bar similar to the one that we use for transcribing. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop audio upload on the home page with full-page overlay and auto-creation of projects.
  * Streamed uploads with real-time progress indicators and progress messaging aligned with transcription UI.
  * Automatic persistence of uploaded audio and navigation to the editor/recorder after upload.
  * GitHub link added to the application header.

* **UI**
  * Status wording updated to distinguish recorded vs. uploaded audio ("Audio ready"). 

* **Documentation**
  * Added a PR status badge to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->