### PR TITLE
chore: add .zenflow to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 .pi/
 .vibe/
 .windsurf/
+.zenflow/
 
 # Internal docs
 handoff.md


### PR DESCRIPTION
Adds `.zenflow/` to the AI/IDE tool configs section of `.gitignore` to prevent workflow task files from being committed.

The `.zenflow` directory was accidentally committed on a feature branch — this ensures it stays ignored going forward.