### PR TITLE
feat: support VAD-based paragraph segments

### DIFF
--- a/src/components/editor/TranscriptEditor.tsx
+++ b/src/components/editor/TranscriptEditor.tsx
@@ -6,12 +6,13 @@ import { useAudioPlayer } from "@/hooks/useAudioPlayer";
 import { audioBufferToWav } from "@/lib/audio";
 import { renderPiecesToBuffer } from "@/lib/audio/offlineRender";
 import { cn } from "@/lib/utils";
-import type { Word } from "@/types";
+import type { Segment, Word } from "@/types";
 
 interface TranscriptEditorProps {
   audioBuffer: AudioBuffer | null;
   initialText: string;
   words: Word[];
+  segments: Segment[];
   projectId: string;
   onTranscriptChange: (text: string, words: Word[]) => void;
 }
@@ -19,6 +20,7 @@ interface TranscriptEditorProps {
 export function TranscriptEditor({
   audioBuffer,
   words: initialWords,
+  segments,
   onTranscriptChange,
   projectId,
 }: TranscriptEditorProps) {
@@ -247,43 +249,118 @@ export function TranscriptEditor({
 
         {/* Interactive Transcript */}
         <div className="min-h-[400px] p-6 bg-background border border-border rounded-lg shadow-inner">
-          <div className="flex flex-wrap gap-x-1.5 gap-y-2 leading-relaxed">
-            {wordsWithOffsets.map((word, index) => {
-              const isActive =
-                isPlaying &&
-                !word.deleted &&
-                currentTime >= word.logicalStart &&
-                currentTime < word.logicalStart + word.wordDuration;
+          {segments && segments.length > 0 ? (
+            <div className="space-y-6">
+              {segments.map((segment, segIdx) => {
+                // Find all words from wordsWithOffsets that belong to this segment
+                const segmentWordsWithIndexes = wordsWithOffsets
+                  .map((word, index) => ({ word, index }))
+                  .filter(
+                    ({ word }) =>
+                      word.start >= segment.start && word.start <= segment.end,
+                  );
 
-              return (
-                <span
-                  key={`${index}-${word.word}`}
-                  onClick={() =>
-                    !word.deleted && handleWordClick(word.logicalStart)
-                  }
-                  onContextMenu={(e) => {
-                    e.preventDefault();
-                    toggleWordDeletion(index);
-                  }}
-                  className={cn(
-                    "px-1 py-0.5 rounded cursor-pointer transition-all duration-200 select-none text-lg",
-                    word.deleted
-                      ? "text-muted-foreground/30 line-through scale-95"
-                      : "text-foreground hover:bg-muted",
-                    isActive &&
-                      "bg-primary text-primary-foreground shadow-sm scale-110 z-10",
-                  )}
-                  title={
-                    word.deleted
-                      ? "Right-click to restore"
-                      : "Click to seek, Right-click to delete"
-                  }
-                >
-                  {word.word}
-                </span>
-              );
-            })}
-          </div>
+                if (segmentWordsWithIndexes.length === 0) return null;
+
+                return (
+                  <div
+                    key={segment.id || segIdx}
+                    className="p-5 bg-card/40 border border-border/50 rounded-xl space-y-3 hover:border-border/80 transition-colors duration-200"
+                  >
+                    {/* Header for the segment */}
+                    <div className="flex items-center justify-between text-xs text-muted-foreground font-mono pb-2 border-b border-border/40">
+                      <div className="flex items-center gap-2">
+                        <span className="w-2 h-2 rounded-full bg-primary/60" />
+                        <span className="font-semibold text-foreground/80">
+                          {segment.speaker || `Speaker ${segIdx + 1}`}
+                        </span>
+                      </div>
+                      <span>
+                        {formatTime(segment.start)} - {formatTime(segment.end)}
+                      </span>
+                    </div>
+
+                    {/* Words wrapper */}
+                    <div className="flex flex-wrap gap-x-1.5 gap-y-2.5 leading-relaxed">
+                      {segmentWordsWithIndexes.map(({ word, index }) => {
+                        const isActive =
+                          isPlaying &&
+                          !word.deleted &&
+                          currentTime >= word.logicalStart &&
+                          currentTime < word.logicalStart + word.wordDuration;
+
+                        return (
+                          <span
+                            key={`${index}-${word.word}`}
+                            onClick={() =>
+                              !word.deleted && handleWordClick(word.logicalStart)
+                            }
+                            onContextMenu={(e) => {
+                              e.preventDefault();
+                              toggleWordDeletion(index);
+                            }}
+                            className={cn(
+                              "px-1 py-0.5 rounded cursor-pointer transition-all duration-150 select-none text-lg",
+                              word.deleted
+                                ? "text-muted-foreground/30 line-through scale-95"
+                                : "text-foreground hover:bg-muted/80",
+                              isActive &&
+                                "bg-primary text-primary-foreground shadow-md scale-110 z-10 font-medium",
+                            )}
+                            title={
+                              word.deleted
+                                ? "Right-click to restore"
+                                : "Click to seek, Right-click to delete"
+                            }
+                          >
+                            {word.word}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="flex flex-wrap gap-x-1.5 gap-y-2 leading-relaxed">
+              {wordsWithOffsets.map((word, index) => {
+                const isActive =
+                  isPlaying &&
+                  !word.deleted &&
+                  currentTime >= word.logicalStart &&
+                  currentTime < word.logicalStart + word.wordDuration;
+
+                return (
+                  <span
+                    key={`${index}-${word.word}`}
+                    onClick={() =>
+                      !word.deleted && handleWordClick(word.logicalStart)
+                    }
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      toggleWordDeletion(index);
+                    }}
+                    className={cn(
+                      "px-1 py-0.5 rounded cursor-pointer transition-all duration-200 select-none text-lg",
+                      word.deleted
+                        ? "text-muted-foreground/30 line-through scale-95"
+                        : "text-foreground hover:bg-muted",
+                      isActive &&
+                        "bg-primary text-primary-foreground shadow-sm scale-110 z-10",
+                    )}
+                    title={
+                      word.deleted
+                        ? "Right-click to restore"
+                        : "Click to seek, Right-click to delete"
+                    }
+                  >
+                    {word.word}
+                  </span>
+                );
+              })}
+            </div>
+          )}
         </div>
 
         <div className="mt-6 flex items-center justify-between text-sm text-muted-foreground bg-muted/30 p-4 rounded-lg">

--- a/src/components/editor/TranscriptEditor.tsx
+++ b/src/components/editor/TranscriptEditor.tsx
@@ -290,8 +290,9 @@ export function TranscriptEditor({
                           currentTime < word.logicalStart + word.wordDuration;
 
                         return (
-                          <span
-                            key={`${index}-${word.word}`}
+                          <button
+                            key={word.start}
+                            type="button"
                             onClick={() =>
                               !word.deleted && handleWordClick(word.logicalStart)
                             }
@@ -299,8 +300,19 @@ export function TranscriptEditor({
                               e.preventDefault();
                               toggleWordDeletion(index);
                             }}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                if (!word.deleted) {
+                                  handleWordClick(word.logicalStart);
+                                }
+                              } else if (e.key === "Backspace" || e.key === "Delete") {
+                                e.preventDefault();
+                                toggleWordDeletion(index);
+                              }
+                            }}
                             className={cn(
-                              "px-1 py-0.5 rounded cursor-pointer transition-all duration-150 select-none text-lg",
+                              "px-1 py-0.5 rounded cursor-pointer transition-all duration-150 select-none text-lg border-0 bg-transparent text-left font-normal focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2",
                               word.deleted
                                 ? "text-muted-foreground/30 line-through scale-95"
                                 : "text-foreground hover:bg-muted/80",
@@ -310,11 +322,11 @@ export function TranscriptEditor({
                             title={
                               word.deleted
                                 ? "Right-click to restore"
-                                : "Click to seek, Right-click to delete"
+                                : "Click/Press Enter/Space to seek, Right-click/Backspace/Delete to delete"
                             }
                           >
                             {word.word}
-                          </span>
+                          </button>
                         );
                       })}
                     </div>
@@ -332,8 +344,9 @@ export function TranscriptEditor({
                   currentTime < word.logicalStart + word.wordDuration;
 
                 return (
-                  <span
-                    key={`${index}-${word.word}`}
+                  <button
+                    key={word.start}
+                    type="button"
                     onClick={() =>
                       !word.deleted && handleWordClick(word.logicalStart)
                     }
@@ -341,8 +354,19 @@ export function TranscriptEditor({
                       e.preventDefault();
                       toggleWordDeletion(index);
                     }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        if (!word.deleted) {
+                          handleWordClick(word.logicalStart);
+                        }
+                      } else if (e.key === "Backspace" || e.key === "Delete") {
+                        e.preventDefault();
+                        toggleWordDeletion(index);
+                      }
+                    }}
                     className={cn(
-                      "px-1 py-0.5 rounded cursor-pointer transition-all duration-200 select-none text-lg",
+                      "px-1 py-0.5 rounded cursor-pointer transition-all duration-200 select-none text-lg border-0 bg-transparent text-left font-normal focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2",
                       word.deleted
                         ? "text-muted-foreground/30 line-through scale-95"
                         : "text-foreground hover:bg-muted",
@@ -352,11 +376,11 @@ export function TranscriptEditor({
                     title={
                       word.deleted
                         ? "Right-click to restore"
-                        : "Click to seek, Right-click to delete"
+                        : "Click/Press Enter/Space to seek, Right-click/Backspace/Delete to delete"
                     }
                   >
                     {word.word}
-                  </span>
+                  </button>
                 );
               })}
             </div>

--- a/src/components/recorder/Recorder.tsx
+++ b/src/components/recorder/Recorder.tsx
@@ -529,6 +529,7 @@ export function Recorder({ project, onSave }: RecorderProps) {
           audioBuffer={audioBuffer}
           initialText={transcriptText}
           words={transcriptWords}
+          segments={project.transcript?.segments || []}
           projectId={project.id}
           onTranscriptChange={handleTranscriptChange}
         />

--- a/src/lib/transcription/transformers-whisper.test.ts
+++ b/src/lib/transcription/transformers-whisper.test.ts
@@ -54,13 +54,27 @@ vi.mock("@huggingface/transformers", () => {
     text: "Hello this is a test transcription of long audio.",
   });
 
+  const mockProcessorInstance = Object.assign(
+    () => Promise.resolve({}),
+    {
+      post_process_speaker_diarization: vi.fn().mockReturnValue([
+        [
+          { start: 10, end: 105, id: "SPEAKER_00" },
+        ],
+      ]),
+    }
+  );
+
   return {
     pipeline: vi.fn().mockResolvedValue(transcriberMock),
     AutoModelForCTC: {
       from_pretrained: vi.fn().mockResolvedValue({}),
     },
+    AutoModelForAudioFrameClassification: {
+      from_pretrained: vi.fn().mockResolvedValue(() => Promise.resolve({ logits: {} })),
+    },
     AutoProcessor: {
-      from_pretrained: vi.fn().mockResolvedValue(() => Promise.resolve({})),
+      from_pretrained: vi.fn().mockResolvedValue(mockProcessorInstance),
     },
     AutoTokenizer: {
       from_pretrained: vi.fn().mockResolvedValue({

--- a/src/lib/transcription/transformers-whisper.ts
+++ b/src/lib/transcription/transformers-whisper.ts
@@ -247,11 +247,13 @@ export async function transcribeAudio(
 
   const allWords: Word[] = [];
   let fullText = "";
+  const resultSegments: { id: string; start: number; end: number; text: string }[] = [];
 
   // STEP 2: Process each speech segment
   for (let i = 0; i < processedSegments.length; i++) {
     const segment = processedSegments[i];
     const segmentDuration = segment.end - segment.start;
+    const segmentStartIdx = allWords.length;
     console.log(
       `[TextCast] Processing segment ${i + 1}/${processedSegments.length} (${segment.start.toFixed(2)}s - ${segment.end.toFixed(2)}s)`,
     );
@@ -335,6 +337,16 @@ export async function transcribeAudio(
       });
     }
 
+    const segmentWords = allWords.slice(segmentStartIdx);
+    if (segmentWords.length > 0) {
+      resultSegments.push({
+        id: `seg-${i}-${Date.now()}`,
+        start: segment.start,
+        end: segment.end,
+        text: segmentWords.map((w) => w.word).join(" "),
+      });
+    }
+
     if (onProgress) {
       onProgress({
         status: "progress",
@@ -346,7 +358,7 @@ export async function transcribeAudio(
 
   return {
     text: fullText.trim(),
-    segments: [],
+    segments: resultSegments,
     words: allWords,
   };
 }

--- a/src/lib/transcription/transformers-whisper.ts
+++ b/src/lib/transcription/transformers-whisper.ts
@@ -5,6 +5,7 @@ import {
   env,
   type ProgressCallback,
   pipeline,
+  AutoModelForAudioFrameClassification,
 } from "@huggingface/transformers";
 import type { Word } from "@/types";
 import { align } from "./aligner";
@@ -52,6 +53,8 @@ let transcriber: Transcriber | null = null;
 let alignerModel: AlignerModel | null = null;
 let alignerProcessor: AlignerProcessor | null = null;
 let alignerTokenizer: AlignerTokenizer | null = null;
+let diarizationModel: any = null;
+let diarizationProcessor: any = null;
 
 export type ModelSize =
   | "Xenova/whisper-tiny.en"
@@ -59,6 +62,7 @@ export type ModelSize =
   | "onnx-community/whisper-large-v3-turbo";
 
 const ALIGNER_MODEL_ID = "onnx-community/mms-300m-1130-forced-aligner-ONNX";
+const DIARIZATION_MODEL_ID = "onnx-community/pyannote-segmentation-3.0";
 
 /**
  * Check if WebGPU is available
@@ -119,7 +123,27 @@ export async function loadModel(
     });
   }
 
-  return { transcriber, alignerModel, alignerProcessor, alignerTokenizer };
+  if (!diarizationModel) {
+    console.log(`[TextCast] Loading Diarization: ${DIARIZATION_MODEL_ID}`);
+    // NOTE: WebGPU is not currently supported for pyannote in ORT Web
+    diarizationModel = await AutoModelForAudioFrameClassification.from_pretrained(DIARIZATION_MODEL_ID, {
+      device: "wasm",
+      dtype: "fp32",
+      progress_callback: onProgress,
+    });
+    diarizationProcessor = await AutoProcessor.from_pretrained(DIARIZATION_MODEL_ID, {
+      progress_callback: onProgress,
+    });
+  }
+
+  return {
+    transcriber,
+    alignerModel,
+    alignerProcessor,
+    alignerTokenizer,
+    diarizationModel,
+    diarizationProcessor,
+  };
 }
 
 /**
@@ -247,7 +271,7 @@ export async function transcribeAudio(
 
   const allWords: Word[] = [];
   let fullText = "";
-  const resultSegments: { id: string; start: number; end: number; text: string }[] = [];
+  const resultSegments: { id: string; start: number; end: number; text: string; speaker?: string }[] = [];
 
   // STEP 2: Process each speech segment
   for (let i = 0; i < processedSegments.length; i++) {
@@ -356,9 +380,117 @@ export async function transcribeAudio(
     }
   }
 
+  // --- STAGE 3: SPEAKER DIARIZATION (PyAnnote) ---
+  let finalSegments = resultSegments;
+  try {
+    if (diarizationModel && diarizationProcessor) {
+      console.log("[TextCast] Running PyAnnote Speaker Diarization on full audio...");
+      if (onProgress) {
+        onProgress({
+          status: "progress",
+          progress: 98,
+          message: "Performing Speaker Diarization...",
+          // biome-ignore lint/suspicious/noExplicitAny: library types
+        } as any);
+      }
+
+      const inputs = await diarizationProcessor(audioData);
+      const { logits } = await diarizationModel(inputs);
+      const speakerSegmentsRaw = diarizationProcessor.post_process_speaker_diarization(logits, audioData.length);
+      const speakerSegments = speakerSegmentsRaw[0] || [];
+
+      console.log(`[TextCast] Diarization finished. Found ${speakerSegments.length} speaker chunks.`);
+
+      if (speakerSegments.length > 0 && allWords.length > 0) {
+        // Map speaker names (e.g. SPEAKER_00 -> Speaker A)
+        const speakerNames: Record<string, string> = {};
+        let speakerCount = 0;
+        const getSpeakerLabel = (id: string): string => {
+          if (!speakerNames[id]) {
+            const label = String.fromCharCode(65 + speakerCount); // 'A', 'B', 'C', ...
+            speakerNames[id] = `Speaker ${label}`;
+            speakerCount++;
+          }
+          return speakerNames[id];
+        };
+
+        // Assign speaker to each word
+        for (const word of allWords) {
+          let bestSpeaker = "SPEAKER_00";
+          let maxOverlap = 0;
+          for (const seg of speakerSegments) {
+            const overlapStart = Math.max(word.start, seg.start);
+            const overlapEnd = Math.min(word.end, seg.end);
+            const overlap = overlapEnd - overlapStart;
+            if (overlap > maxOverlap) {
+              maxOverlap = overlap;
+              bestSpeaker = seg.id;
+            }
+          }
+          // Fallback if no overlap: find closest segment
+          if (maxOverlap === 0 && speakerSegments.length > 0) {
+            let minDistance = Infinity;
+            for (const seg of speakerSegments) {
+              const dist = Math.min(Math.abs(word.start - seg.end), Math.abs(seg.start - word.end));
+              if (dist < minDistance) {
+                minDistance = dist;
+                bestSpeaker = seg.id;
+              }
+            }
+          }
+          word.speaker = getSpeakerLabel(bestSpeaker);
+        }
+
+        // Re-construct contiguous segments based on speaker changes or long pauses
+        const diarizedSegments: typeof resultSegments = [];
+        let currentSegmentWords: Word[] = [allWords[0]];
+        let currentSpeaker = allWords[0].speaker || "Speaker A";
+        let segmentStart = allWords[0].start;
+
+        for (let i = 1; i < allWords.length; i++) {
+          const word = allWords[i];
+          const wordSpeaker = word.speaker || "Speaker A";
+          const prevWord = allWords[i - 1];
+
+          const speakerChanged = wordSpeaker !== currentSpeaker;
+          const isLongPause = word.start - prevWord.end > 2.0;
+
+          if (speakerChanged || isLongPause) {
+            diarizedSegments.push({
+              id: `seg-${diarizedSegments.length}-${Date.now()}`,
+              start: segmentStart,
+              end: prevWord.end,
+              text: currentSegmentWords.map((w) => w.word).join(" "),
+              speaker: currentSpeaker,
+            });
+            currentSegmentWords = [word];
+            currentSpeaker = wordSpeaker;
+            segmentStart = word.start;
+          } else {
+            currentSegmentWords.push(word);
+          }
+        }
+
+        if (currentSegmentWords.length > 0) {
+          diarizedSegments.push({
+            id: `seg-${diarizedSegments.length}-${Date.now()}`,
+            start: segmentStart,
+            end: currentSegmentWords[currentSegmentWords.length - 1].end,
+            text: currentSegmentWords.map((w) => w.word).join(" "),
+            speaker: currentSpeaker,
+          });
+        }
+
+        finalSegments = diarizedSegments;
+      }
+    }
+  } catch (err) {
+    console.error("[TextCast] Diarization failed, falling back to basic VAD segments:", err);
+  }
+
   return {
     text: fullText.trim(),
-    segments: resultSegments,
+    segments: finalSegments,
     words: allWords,
   };
 }

--- a/src/lib/transcription/transformers-whisper.ts
+++ b/src/lib/transcription/transformers-whisper.ts
@@ -364,7 +364,7 @@ export async function transcribeAudio(
     const segmentWords = allWords.slice(segmentStartIdx);
     if (segmentWords.length > 0) {
       resultSegments.push({
-        id: `seg-${i}-${Date.now()}`,
+        id: crypto.randomUUID(),
         start: segment.start,
         end: segment.end,
         text: segmentWords.map((w) => w.word).join(" "),
@@ -457,7 +457,7 @@ export async function transcribeAudio(
 
           if (speakerChanged || isLongPause) {
             diarizedSegments.push({
-              id: `seg-${diarizedSegments.length}-${Date.now()}`,
+              id: crypto.randomUUID(),
               start: segmentStart,
               end: prevWord.end,
               text: currentSegmentWords.map((w) => w.word).join(" "),
@@ -473,7 +473,7 @@ export async function transcribeAudio(
 
         if (currentSegmentWords.length > 0) {
           diarizedSegments.push({
-            id: `seg-${diarizedSegments.length}-${Date.now()}`,
+            id: crypto.randomUUID(),
             start: segmentStart,
             end: currentSegmentWords[currentSegmentWords.length - 1].end,
             text: currentSegmentWords.map((w) => w.word).join(" "),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export interface Word {
   confidence: number;
   deleted?: boolean;
   playbackBuffer?: AudioBuffer; // Reference to the source buffer for this word
+  speaker?: string;
 }
 
 export interface Segment {


### PR DESCRIPTION
This PR implements structural VAD-based speech segment paragraphs. By mapping word-level timestamps to their respective Silero VAD speech turns, we split the transcript from a single monolithic wall of text into distinct conversational bubbles/cards grouped by speakers and timestamp intervals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Transcript editor now organizes transcripts by speaker segments for improved readability and navigation.
* Enhanced transcript interactivity with automatic segment detection and synchronized word highlighting during audio playback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sirmews/textcast/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->