### PR TITLE
feat: implement interactive sound waveform synced with Piece Table EDL

### DIFF
--- a/src/components/editor/TranscriptEditor.tsx
+++ b/src/components/editor/TranscriptEditor.tsx
@@ -2,6 +2,7 @@ import { Download, Loader2, Pause, Play, Wand2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Orb } from "@/components/ui/orb";
+import { AudioWaveform } from "@/components/ui/AudioWaveform";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
 import { audioBufferToWav } from "@/lib/audio";
 import { renderPiecesToBuffer } from "@/lib/audio/offlineRender";
@@ -231,21 +232,15 @@ export function TranscriptEditor({
           </div>
         </div>
 
-        {/* Progress Bar */}
-        <div
-          className="relative w-full h-2 bg-muted rounded-full mb-8 cursor-pointer overflow-hidden"
-          onClick={(e) => {
-            const rect = e.currentTarget.getBoundingClientRect();
-            const x = e.clientX - rect.left;
-            const pct = x / rect.width;
-            seek(pct * duration);
-          }}
-        >
-          <div
-            className="absolute top-0 left-0 h-full bg-primary transition-all duration-100 ease-linear"
-            style={{ width: `${(currentTime / duration) * 100}%` }}
-          />
-        </div>
+        {/* Interactive Waveform representing Piece Table EDL */}
+        <AudioWaveform
+          audioBuffer={audioBuffer}
+          currentTime={currentTime}
+          pieces={pieces}
+          words={wordList}
+          onSeek={seek}
+          className="mb-8"
+        />
 
         {/* Interactive Transcript */}
         <div className="min-h-[400px] p-6 bg-background border border-border rounded-lg shadow-inner">

--- a/src/components/editor/TranscriptEditor.tsx
+++ b/src/components/editor/TranscriptEditor.tsx
@@ -396,62 +396,8 @@ export function TranscriptEditor({
           </div>
           <p>
             {wordList.filter((w) => w.deleted).length} words removed from
-            timeline
+            timeline • {pieces.length} active pieces
           </p>
-        </div>
-
-        {/* Piece Table Visualization (EDL) */}
-        <div className="mt-8 p-4 bg-muted/20 border border-border rounded-lg">
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-medium">
-              Under the Hood: Piece Table (EDL)
-            </h3>
-            <span className="text-xs text-muted-foreground font-mono">
-              Original Buffer: {formatTime(audioBuffer?.duration || 0)}
-            </span>
-          </div>
-
-          <div className="relative w-full h-10 bg-destructive/20 rounded overflow-hidden shadow-inner">
-            {/* The background represents the full original file (red = deleted/omitted) */}
-            {pieces.map((piece, i) => {
-              const totalOriginalLength = audioBuffer?.duration || 1;
-              const leftPercent =
-                (piece.sourceOffset / totalOriginalLength) * 100;
-              const widthPercent = (piece.length / totalOriginalLength) * 100;
-
-              return (
-                <div
-                  key={i}
-                  className="absolute top-0 h-full bg-emerald-500 border-r border-background/50 last:border-none flex items-center justify-center overflow-hidden hover:brightness-110 transition-all cursor-crosshair"
-                  style={{
-                    left: `${leftPercent}%`,
-                    width: `${widthPercent}%`,
-                  }}
-                  title={`Piece ${i + 1}\nSource Offset: ${piece.sourceOffset.toFixed(2)}s\nLength: ${piece.length.toFixed(2)}s`}
-                >
-                  {widthPercent > 5 && (
-                    <span className="text-[10px] font-mono font-medium text-emerald-950 px-1 truncate">
-                      P{i + 1}
-                    </span>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-
-          <div className="mt-3 flex gap-4 text-xs text-muted-foreground">
-            <div className="flex items-center gap-1.5">
-              <span className="w-3 h-3 bg-emerald-500 rounded-sm shadow-sm"></span>
-              <span>Active Audio Blocks</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <span className="w-3 h-3 bg-destructive/20 rounded-sm shadow-inner"></span>
-              <span>Deleted Regions (Skipped)</span>
-            </div>
-            <div className="ml-auto">
-              <span className="font-mono">Total Pieces: {pieces.length}</span>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/src/components/ui/AudioWaveform.tsx
+++ b/src/components/ui/AudioWaveform.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { extractPeaks } from "@/lib/audio/peaks";
 import type { Piece } from "@/lib/audio/PieceTable";
 import type { Word } from "@/types";
@@ -8,7 +8,7 @@ interface AudioWaveformProps {
   audioBuffer: AudioBuffer | null;
   currentTime: number; // Logical time from player
   pieces: Piece[]; // Edit Decision List pieces
-  words: Word[]; // Original transribed words
+  words: Word[]; // Original transcribed words
   onSeek: (logicalTime: number) => void;
   className?: string;
 }
@@ -28,7 +28,6 @@ function getAbsoluteTime(logicalTime: number, pieces: Piece[]): number {
     accum += piece.length;
   }
   
-  // Return the logicalTime as fallback if out of bounds
   return logicalTime;
 }
 
@@ -49,7 +48,7 @@ function getLogicalTime(absoluteTime: number, pieces: Piece[]): number {
     accum += piece.length;
   }
 
-  // Fallback: If clicked in a deleted region, snap to the nearest boundary of any active piece
+  // Fallback: If clicked in a deleted region, snap to nearest active piece boundary
   let closestLogical = 0;
   let minDiff = Infinity;
   let tempAccum = 0;
@@ -81,7 +80,15 @@ export function AudioWaveform({
   className,
 }: AudioWaveformProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const NUMBER_OF_PEAKS = 350;
+  const [hoverPercent, setHoverPercent] = useState<number | null>(null);
+
+  // Render exactly 250 bars. SVG will scale this responsively to any screen width.
+  const NUMBER_OF_PEAKS = 250;
+  // SVG internal coordinates: width 1000, height 100.
+  const SVG_WIDTH = 1000;
+  const SVG_HEIGHT = 100;
+  const BAR_SPACING = SVG_WIDTH / NUMBER_OF_PEAKS; // 4 units per bar
+  const BAR_WIDTH = BAR_SPACING * 0.65; // 2.6 units width, 1.4 units gap
 
   // 1. Calculate the peaks once per AudioBuffer load
   const peaks = useMemo(() => {
@@ -92,8 +99,7 @@ export function AudioWaveform({
 
   const totalDuration = audioBuffer?.duration || 0;
 
-  // 2. Pre-calculate active/deleted status for each peak index
-  // Each peak index represents a duration bucket = totalDuration / NUMBER_OF_PEAKS
+  // 2. Pre-calculate active/deleted status and geometry for each peak index
   const peakStates = useMemo(() => {
     if (peaks.length === 0 || totalDuration === 0) return [];
 
@@ -102,18 +108,26 @@ export function AudioWaveform({
     return peaks.map((val, i) => {
       const peakTime = i * bucketDuration;
 
-      // Find if this peak time is inside any deleted word
+      // Check if this peak's absolute timestamp falls inside any deleted word
       const isDeleted = words.some(
         (word) => word.deleted && peakTime >= word.start && peakTime <= word.end
       );
 
+      // Center the bar vertically
+      const barHeight = Math.max(8, val * SVG_HEIGHT * 0.85); // minimum 8 units height for silence
+      const y = (SVG_HEIGHT - barHeight) / 2;
+      const x = i * BAR_SPACING;
+
       return {
-        val,
+        x,
+        y,
+        width: BAR_WIDTH,
+        height: barHeight,
         isDeleted,
         time: peakTime,
       };
     });
-  }, [peaks, words, totalDuration]);
+  }, [peaks, words, totalDuration, BAR_SPACING, BAR_WIDTH]);
 
   // 3. Map logical playhead time to absolute playhead position (0.0 to 100.0%)
   const absolutePlayheadPercent = useMemo(() => {
@@ -131,9 +145,29 @@ export function AudioWaveform({
     const clickPercent = Math.min(1.0, Math.max(0.0, clickX / rect.width));
     const targetAbsoluteTime = clickPercent * totalDuration;
 
-    // Convert absolute clicked position back to logical playhead time and invoke seek callback
     const targetLogicalTime = getLogicalTime(targetAbsoluteTime, pieces);
     onSeek(targetLogicalTime);
+  };
+
+  // 5. Handle mouse move for professional hovering effects
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!containerRef.current || totalDuration === 0) return;
+
+    const rect = containerRef.current.getBoundingClientRect();
+    const hoverX = e.clientX - rect.left;
+    const percent = Math.min(1.0, Math.max(0.0, hoverX / rect.width));
+    setHoverPercent(percent);
+  };
+
+  const handleMouseLeave = () => {
+    setHoverPercent(null);
+  };
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    const ms = Math.floor((seconds % 1) * 10);
+    return `${mins}:${secs.toString().padStart(2, "0")}.${ms}`;
   };
 
   if (!audioBuffer || peaks.length === 0) {
@@ -145,52 +179,130 @@ export function AudioWaveform({
   }
 
   return (
-    <div className={cn("space-y-2", className)}>
+    <div className={cn("space-y-2 select-none", className)}>
       <div className="flex items-center justify-between text-xs text-muted-foreground font-mono px-1">
-        <span>Waveform (Original Cut)</span>
-        <span>Click to seek playhead</span>
+        <span>Timeline Overview</span>
+        <span className="text-primary/80 font-medium">
+          {hoverPercent !== null ? `Seek to: ${formatTime(hoverPercent * totalDuration)}` : `Playhead: ${formatTime(getAbsoluteTime(currentTime, pieces))}`}
+        </span>
       </div>
 
       <div
         ref={containerRef}
         onClick={handleContainerClick}
-        className="relative w-full h-24 bg-background/50 border border-border rounded-xl flex items-center justify-between px-3 cursor-pointer select-none overflow-hidden hover:border-border/80 transition-colors duration-200"
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        className="relative w-full h-24 bg-background/40 border border-border/80 rounded-xl cursor-pointer overflow-hidden hover:border-border transition-colors duration-200"
       >
-        {/* Playhead Indicator Line */}
-        <div
-          className="absolute top-0 bottom-0 w-0.5 bg-primary z-30 pointer-events-none transition-all duration-75 ease-linear shadow-[0_0_8px_rgba(var(--primary-color),0.5)]"
-          style={{ left: `calc(${absolutePlayheadPercent}% - 0px)` }}
-        />
-
-        {/* Shaded played-portion overlay */}
-        <div
-          className="absolute top-0 bottom-0 left-0 bg-primary/5 z-10 pointer-events-none transition-all duration-75 ease-linear"
-          style={{ width: `${absolutePlayheadPercent}%` }}
-        />
-
-        {/* Peak Column Grid */}
-        <div className="w-full h-16 flex items-center justify-between gap-0.5 z-20">
-          {peakStates.map((state, index) => {
-            const peakPercent = (state.time / totalDuration) * 100;
-            const isPlayed = peakPercent <= absolutePlayheadPercent;
-
-            return (
-              <div
-                key={index}
-                style={{ height: `${Math.max(10, state.val * 100)}%` }}
-                className={cn(
-                  "w-[2px] rounded-full transition-colors duration-150",
-                  state.isDeleted
-                    ? "bg-muted-foreground/15 dark:bg-muted-foreground/10 line-through decoration-destructive/30"
-                    : isPlayed
-                    ? "bg-primary"
-                    : "bg-primary/30 dark:bg-primary/20"
-                )}
-                title={`Time: ${state.time.toFixed(2)}s`}
+        {/* Wavesurfer Dual-Wave Rendering via SVG */}
+        <svg
+          className="w-full h-full p-2 overflow-visible"
+          viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+          preserveAspectRatio="none"
+        >
+          {/* Progress Clipping Mask (Clipped to playhead location) */}
+          <defs>
+            <clipPath id="waveform-progress-clip">
+              <rect
+                x="0"
+                y="-10"
+                width={absolutePlayheadPercent * (SVG_WIDTH / 100)}
+                height={SVG_HEIGHT + 20}
               />
-            );
-          })}
-        </div>
+            </clipPath>
+          </defs>
+
+          {/* Group 1: Background Waveform (Unplayed Portion - Muted Violet/Gray) */}
+          <g className="text-primary/20 dark:text-primary/15 transition-all duration-75">
+            {peakStates.map((state, index) => {
+              if (state.isDeleted) {
+                return (
+                  <rect
+                    key={`bg-del-${index}`}
+                    x={state.x}
+                    y={state.y}
+                    width={state.width}
+                    height={state.height}
+                    rx="1.3"
+                    ry="1.3"
+                    className="fill-muted-foreground/10 dark:fill-muted-foreground/5"
+                  />
+                );
+              }
+              return (
+                <rect
+                  key={`bg-active-${index}`}
+                  x={state.x}
+                  y={state.y}
+                  width={state.width}
+                  height={state.height}
+                  rx="1.3"
+                  ry="1.3"
+                  fill="currentColor"
+                />
+              );
+            })}
+          </g>
+
+          {/* Group 2: Foreground Waveform (Played Portion - Clipped to Playhead with vibrant Primary fill) */}
+          <g
+            className="text-primary transition-all duration-75"
+            clipPath="url(#waveform-progress-clip)"
+          >
+            {peakStates.map((state, index) => {
+              // Deleted parts don't light up as played to keep focus on edited state
+              if (state.isDeleted) return null;
+
+              return (
+                <rect
+                  key={`fg-active-${index}`}
+                  x={state.x}
+                  y={state.y}
+                  width={state.width}
+                  height={state.height}
+                  rx="1.3"
+                  ry="1.3"
+                  fill="currentColor"
+                />
+              );
+            })}
+          </g>
+
+          {/* Group 3: Strike-through decorations for Deleted Blocks */}
+          <g className="text-muted-foreground/30 dark:text-muted-foreground/20">
+            {peakStates.map((state, index) => {
+              if (!state.isDeleted) return null;
+              
+              // Draw a small cross line in the middle of deleted buckets
+              return (
+                <line
+                  key={`strike-${index}`}
+                  x1={state.x - 1}
+                  y1={SVG_HEIGHT / 2}
+                  x2={state.x + state.width + 1}
+                  y2={SVG_HEIGHT / 2}
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeDasharray="1 1"
+                />
+              );
+            })}
+          </g>
+        </svg>
+
+        {/* Wavesurfer Hover Timeline Indicator Line */}
+        {hoverPercent !== null && (
+          <div
+            className="absolute top-0 bottom-0 w-[1.5px] bg-muted-foreground/40 pointer-events-none z-30"
+            style={{ left: `${hoverPercent * 100}%` }}
+          />
+        )}
+
+        {/* Wavesurfer Sliding Playhead Indicator Line */}
+        <div
+          className="absolute top-0 bottom-0 w-0.5 bg-primary z-40 pointer-events-none transition-all duration-75 ease-linear shadow-[0_0_10px_rgba(var(--primary-color),0.6)]"
+          style={{ left: `${absolutePlayheadPercent}%` }}
+        />
       </div>
     </div>
   );

--- a/src/components/ui/AudioWaveform.tsx
+++ b/src/components/ui/AudioWaveform.tsx
@@ -1,0 +1,197 @@
+import { useMemo, useRef } from "react";
+import { extractPeaks } from "@/lib/audio/peaks";
+import type { Piece } from "@/lib/audio/PieceTable";
+import type { Word } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface AudioWaveformProps {
+  audioBuffer: AudioBuffer | null;
+  currentTime: number; // Logical time from player
+  pieces: Piece[]; // Edit Decision List pieces
+  words: Word[]; // Original transribed words
+  onSeek: (logicalTime: number) => void;
+  className?: string;
+}
+
+/**
+ * Maps a logical player time back to the absolute time of the original file
+ */
+function getAbsoluteTime(logicalTime: number, pieces: Piece[]): number {
+  if (pieces.length === 0) return logicalTime;
+  
+  let accum = 0;
+  for (const piece of pieces) {
+    if (logicalTime >= accum && logicalTime <= accum + piece.length) {
+      const piecePercent = piece.length > 0 ? (logicalTime - accum) / piece.length : 0;
+      return piece.sourceOffset + piecePercent * piece.length;
+    }
+    accum += piece.length;
+  }
+  
+  // Return the logicalTime as fallback if out of bounds
+  return logicalTime;
+}
+
+/**
+ * Maps an absolute original file time to the logical player time
+ */
+function getLogicalTime(absoluteTime: number, pieces: Piece[]): number {
+  if (pieces.length === 0) return absoluteTime;
+  
+  let accum = 0;
+  for (const piece of pieces) {
+    if (
+      absoluteTime >= piece.sourceOffset &&
+      absoluteTime <= piece.sourceOffset + piece.length
+    ) {
+      return accum + (absoluteTime - piece.sourceOffset);
+    }
+    accum += piece.length;
+  }
+
+  // Fallback: If clicked in a deleted region, snap to the nearest boundary of any active piece
+  let closestLogical = 0;
+  let minDiff = Infinity;
+  let tempAccum = 0;
+
+  for (const piece of pieces) {
+    const startDiff = Math.abs(absoluteTime - piece.sourceOffset);
+    const endDiff = Math.abs(absoluteTime - (piece.sourceOffset + piece.length));
+
+    if (startDiff < minDiff) {
+      minDiff = startDiff;
+      closestLogical = tempAccum;
+    }
+    if (endDiff < minDiff) {
+      minDiff = endDiff;
+      closestLogical = tempAccum + piece.length;
+    }
+    tempAccum += piece.length;
+  }
+
+  return closestLogical;
+}
+
+export function AudioWaveform({
+  audioBuffer,
+  currentTime,
+  pieces,
+  words,
+  onSeek,
+  className,
+}: AudioWaveformProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const NUMBER_OF_PEAKS = 350;
+
+  // 1. Calculate the peaks once per AudioBuffer load
+  const peaks = useMemo(() => {
+    if (!audioBuffer) return [];
+    // Use shapingFactor of 0.7 to visually boost speaking dynamics slightly
+    return extractPeaks(audioBuffer, { numberOfPeaks: NUMBER_OF_PEAKS, shapingFactor: 0.7 });
+  }, [audioBuffer]);
+
+  const totalDuration = audioBuffer?.duration || 0;
+
+  // 2. Pre-calculate active/deleted status for each peak index
+  // Each peak index represents a duration bucket = totalDuration / NUMBER_OF_PEAKS
+  const peakStates = useMemo(() => {
+    if (peaks.length === 0 || totalDuration === 0) return [];
+
+    const bucketDuration = totalDuration / NUMBER_OF_PEAKS;
+    
+    return peaks.map((val, i) => {
+      const peakTime = i * bucketDuration;
+
+      // Find if this peak time is inside any deleted word
+      const isDeleted = words.some(
+        (word) => word.deleted && peakTime >= word.start && peakTime <= word.end
+      );
+
+      return {
+        val,
+        isDeleted,
+        time: peakTime,
+      };
+    });
+  }, [peaks, words, totalDuration]);
+
+  // 3. Map logical playhead time to absolute playhead position (0.0 to 100.0%)
+  const absolutePlayheadPercent = useMemo(() => {
+    if (totalDuration === 0) return 0;
+    const absTime = getAbsoluteTime(currentTime, pieces);
+    return Math.min(100, Math.max(0, (absTime / totalDuration) * 100));
+  }, [currentTime, pieces, totalDuration]);
+
+  // 4. Handle interactive clicks to seek
+  const handleContainerClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!containerRef.current || totalDuration === 0) return;
+
+    const rect = containerRef.current.getBoundingClientRect();
+    const clickX = e.clientX - rect.left;
+    const clickPercent = Math.min(1.0, Math.max(0.0, clickX / rect.width));
+    const targetAbsoluteTime = clickPercent * totalDuration;
+
+    // Convert absolute clicked position back to logical playhead time and invoke seek callback
+    const targetLogicalTime = getLogicalTime(targetAbsoluteTime, pieces);
+    onSeek(targetLogicalTime);
+  };
+
+  if (!audioBuffer || peaks.length === 0) {
+    return (
+      <div className={cn("w-full h-24 bg-muted/20 border border-dashed border-border rounded-lg flex items-center justify-center text-sm text-muted-foreground", className)}>
+        Load an audio buffer to visualize waveform
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <div className="flex items-center justify-between text-xs text-muted-foreground font-mono px-1">
+        <span>Waveform (Original Cut)</span>
+        <span>Click to seek playhead</span>
+      </div>
+
+      <div
+        ref={containerRef}
+        onClick={handleContainerClick}
+        className="relative w-full h-24 bg-background/50 border border-border rounded-xl flex items-center justify-between px-3 cursor-pointer select-none overflow-hidden hover:border-border/80 transition-colors duration-200"
+      >
+        {/* Playhead Indicator Line */}
+        <div
+          className="absolute top-0 bottom-0 w-0.5 bg-primary z-30 pointer-events-none transition-all duration-75 ease-linear shadow-[0_0_8px_rgba(var(--primary-color),0.5)]"
+          style={{ left: `calc(${absolutePlayheadPercent}% - 0px)` }}
+        />
+
+        {/* Shaded played-portion overlay */}
+        <div
+          className="absolute top-0 bottom-0 left-0 bg-primary/5 z-10 pointer-events-none transition-all duration-75 ease-linear"
+          style={{ width: `${absolutePlayheadPercent}%` }}
+        />
+
+        {/* Peak Column Grid */}
+        <div className="w-full h-16 flex items-center justify-between gap-0.5 z-20">
+          {peakStates.map((state, index) => {
+            const peakPercent = (state.time / totalDuration) * 100;
+            const isPlayed = peakPercent <= absolutePlayheadPercent;
+
+            return (
+              <div
+                key={index}
+                style={{ height: `${Math.max(10, state.val * 100)}%` }}
+                className={cn(
+                  "w-[2px] rounded-full transition-colors duration-150",
+                  state.isDeleted
+                    ? "bg-muted-foreground/15 dark:bg-muted-foreground/10 line-through decoration-destructive/30"
+                    : isPlayed
+                    ? "bg-primary"
+                    : "bg-primary/30 dark:bg-primary/20"
+                )}
+                title={`Time: ${state.time.toFixed(2)}s`}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/AudioWaveform.tsx
+++ b/src/components/ui/AudioWaveform.tsx
@@ -84,7 +84,6 @@ export function AudioWaveform({
 
   // Render exactly 250 bars. SVG will scale this responsively to any screen width.
   const NUMBER_OF_PEAKS = 250;
-  // SVG internal coordinates: width 1000, height 100.
   const SVG_WIDTH = 1000;
   const SVG_HEIGHT = 100;
   const BAR_SPACING = SVG_WIDTH / NUMBER_OF_PEAKS; // 4 units per bar
@@ -181,7 +180,7 @@ export function AudioWaveform({
   return (
     <div className={cn("space-y-2 select-none", className)}>
       <div className="flex items-center justify-between text-xs text-muted-foreground font-mono px-1">
-        <span>Timeline Overview</span>
+        <span>Timeline & EDL Editor</span>
         <span className="text-primary/80 font-medium">
           {hoverPercent !== null ? `Seek to: ${formatTime(hoverPercent * totalDuration)}` : `Playhead: ${formatTime(getAbsoluteTime(currentTime, pieces))}`}
         </span>
@@ -192,117 +191,145 @@ export function AudioWaveform({
         onClick={handleContainerClick}
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
-        className="relative w-full h-24 bg-background/40 border border-border/80 rounded-xl cursor-pointer overflow-hidden hover:border-border transition-colors duration-200"
+        className="relative w-full bg-background/40 border border-border/80 rounded-xl cursor-pointer overflow-hidden hover:border-border transition-colors duration-200 flex flex-col"
       >
-        {/* Wavesurfer Dual-Wave Rendering via SVG */}
-        <svg
-          className="w-full h-full p-2 overflow-visible"
-          viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
-          preserveAspectRatio="none"
-        >
-          {/* Progress Clipping Mask (Clipped to playhead location) */}
-          <defs>
-            <clipPath id="waveform-progress-clip">
-              <rect
-                x="0"
-                y="-10"
-                width={absolutePlayheadPercent * (SVG_WIDTH / 100)}
-                height={SVG_HEIGHT + 20}
-              />
-            </clipPath>
-          </defs>
+        {/* Upper Layer: Wavesurfer Dual-Wave Rendering via SVG */}
+        <div className="relative w-full h-20 px-3 flex items-center">
+          <svg
+            className="w-full h-full p-2 overflow-visible"
+            viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+            preserveAspectRatio="none"
+          >
+            {/* Progress Clipping Mask (Clipped to playhead location) */}
+            <defs>
+              <clipPath id="waveform-progress-clip">
+                <rect
+                  x="0"
+                  y="-10"
+                  width={absolutePlayheadPercent * (SVG_WIDTH / 100)}
+                  height={SVG_HEIGHT + 20}
+                />
+              </clipPath>
+            </defs>
 
-          {/* Group 1: Background Waveform (Unplayed Portion - Muted Violet/Gray) */}
-          <g className="text-primary/20 dark:text-primary/15 transition-all duration-75">
-            {peakStates.map((state, index) => {
-              if (state.isDeleted) {
+            {/* Group 1: Background Waveform (Unplayed Portion - Muted Violet/Gray) */}
+            <g className="text-primary/20 dark:text-primary/15 transition-all duration-75">
+              {peakStates.map((state, index) => {
+                if (state.isDeleted) {
+                  return (
+                    <rect
+                      key={`bg-del-${index}`}
+                      x={state.x}
+                      y={state.y}
+                      width={state.width}
+                      height={state.height}
+                      rx="1.3"
+                      ry="1.3"
+                      className="fill-muted-foreground/10 dark:fill-muted-foreground/5"
+                    />
+                  );
+                }
                 return (
                   <rect
-                    key={`bg-del-${index}`}
+                    key={`bg-active-${index}`}
                     x={state.x}
                     y={state.y}
                     width={state.width}
                     height={state.height}
                     rx="1.3"
                     ry="1.3"
-                    className="fill-muted-foreground/10 dark:fill-muted-foreground/5"
+                    fill="currentColor"
                   />
                 );
-              }
-              return (
-                <rect
-                  key={`bg-active-${index}`}
-                  x={state.x}
-                  y={state.y}
-                  width={state.width}
-                  height={state.height}
-                  rx="1.3"
-                  ry="1.3"
-                  fill="currentColor"
-                />
-              );
-            })}
-          </g>
+              })}
+            </g>
 
-          {/* Group 2: Foreground Waveform (Played Portion - Clipped to Playhead with vibrant Primary fill) */}
-          <g
-            className="text-primary transition-all duration-75"
-            clipPath="url(#waveform-progress-clip)"
-          >
-            {peakStates.map((state, index) => {
-              // Deleted parts don't light up as played to keep focus on edited state
-              if (state.isDeleted) return null;
+            {/* Group 2: Foreground Waveform (Played Portion - Clipped to Playhead with vibrant Primary fill) */}
+            <g
+              className="text-primary transition-all duration-75"
+              clipPath="url(#waveform-progress-clip)"
+            >
+              {peakStates.map((state, index) => {
+                // Deleted parts don't light up as played to keep focus on edited state
+                if (state.isDeleted) return null;
 
-              return (
-                <rect
-                  key={`fg-active-${index}`}
-                  x={state.x}
-                  y={state.y}
-                  width={state.width}
-                  height={state.height}
-                  rx="1.3"
-                  ry="1.3"
-                  fill="currentColor"
-                />
-              );
-            })}
-          </g>
+                return (
+                  <rect
+                    key={`fg-active-${index}`}
+                    x={state.x}
+                    y={state.y}
+                    width={state.width}
+                    height={state.height}
+                    rx="1.3"
+                    ry="1.3"
+                    fill="currentColor"
+                  />
+                );
+              })}
+            </g>
 
-          {/* Group 3: Strike-through decorations for Deleted Blocks */}
-          <g className="text-muted-foreground/30 dark:text-muted-foreground/20">
-            {peakStates.map((state, index) => {
-              if (!state.isDeleted) return null;
-              
-              // Draw a small cross line in the middle of deleted buckets
-              return (
-                <line
-                  key={`strike-${index}`}
-                  x1={state.x - 1}
-                  y1={SVG_HEIGHT / 2}
-                  x2={state.x + state.width + 1}
-                  y2={SVG_HEIGHT / 2}
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeDasharray="1 1"
-                />
-              );
-            })}
-          </g>
-        </svg>
+            {/* Group 3: Strike-through decorations for Deleted Blocks */}
+            <g className="text-muted-foreground/30 dark:text-muted-foreground/20">
+              {peakStates.map((state, index) => {
+                if (!state.isDeleted) return null;
+                
+                // Draw a small cross line in the middle of deleted buckets
+                return (
+                  <line
+                    key={`strike-${index}`}
+                    x1={state.x - 1}
+                    y1={SVG_HEIGHT / 2}
+                    x2={state.x + state.width + 1}
+                    y2={SVG_HEIGHT / 2}
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeDasharray="1 1"
+                  />
+                );
+              })}
+            </g>
+          </svg>
 
-        {/* Wavesurfer Hover Timeline Indicator Line */}
-        {hoverPercent !== null && (
+          {/* Wavesurfer Hover Timeline Indicator Line */}
+          {hoverPercent !== null && (
+            <div
+              className="absolute top-0 bottom-0 w-[1.5px] bg-muted-foreground/40 pointer-events-none z-30"
+              style={{ left: `${hoverPercent * 100}%` }}
+            />
+          )}
+
+          {/* Wavesurfer Sliding Playhead Indicator Line */}
           <div
-            className="absolute top-0 bottom-0 w-[1.5px] bg-muted-foreground/40 pointer-events-none z-30"
-            style={{ left: `${hoverPercent * 100}%` }}
+            className="absolute top-0 bottom-0 w-0.5 bg-primary z-40 pointer-events-none transition-all duration-75 ease-linear shadow-[0_0_10px_rgba(var(--primary-color),0.6)]"
+            style={{ left: `${absolutePlayheadPercent}%` }}
           />
-        )}
+        </div>
 
-        {/* Wavesurfer Sliding Playhead Indicator Line */}
-        <div
-          className="absolute top-0 bottom-0 w-0.5 bg-primary z-40 pointer-events-none transition-all duration-75 ease-linear shadow-[0_0_10px_rgba(var(--primary-color),0.6)]"
-          style={{ left: `${absolutePlayheadPercent}%` }}
-        />
+        {/* Lower Layer: Integrated Piece Table (EDL) Timeline Track */}
+        <div className="h-4 w-full bg-destructive/15 border-t border-border/40 relative flex items-center text-left">
+          {pieces.map((piece, i) => {
+            const leftPercent = (piece.sourceOffset / totalDuration) * 100;
+            const widthPercent = (piece.length / totalDuration) * 100;
+
+            return (
+              <div
+                key={i}
+                className="absolute h-full bg-emerald-500/80 dark:bg-emerald-500/70 border-r border-background/40 last:border-none hover:brightness-110 transition-all flex items-center justify-center overflow-hidden"
+                style={{
+                  left: `${leftPercent}%`,
+                  width: `${widthPercent}%`,
+                }}
+                title={`Piece ${i + 1}\nSource Offset: ${piece.sourceOffset.toFixed(2)}s\nLength: ${piece.length.toFixed(2)}s`}
+              >
+                {widthPercent > 2.5 && (
+                  <span className="text-[9px] font-mono font-bold text-emerald-950 dark:text-emerald-950 px-1 truncate">
+                    P{i + 1}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/AudioWaveform.tsx
+++ b/src/components/ui/AudioWaveform.tsx
@@ -113,7 +113,7 @@ export function AudioWaveform({
       );
 
       // Center the bar vertically
-      const barHeight = Math.max(8, val * SVG_HEIGHT * 0.85); // minimum 8 units height for silence
+      const barHeight = Math.max(8, val * SVG_HEIGHT * 0.82); // minimum 8 units height for silence
       const y = (SVG_HEIGHT - barHeight) / 2;
       const x = i * BAR_SPACING;
 
@@ -191,145 +191,167 @@ export function AudioWaveform({
         onClick={handleContainerClick}
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
-        className="relative w-full bg-background/40 border border-border/80 rounded-xl cursor-pointer overflow-hidden hover:border-border transition-colors duration-200 flex flex-col"
+        className="relative w-full h-24 bg-background/40 border border-border/80 rounded-xl cursor-pointer overflow-hidden hover:border-border transition-colors duration-200"
       >
-        {/* Upper Layer: Wavesurfer Dual-Wave Rendering via SVG */}
-        <div className="relative w-full h-20 px-3 flex items-center">
-          <svg
-            className="w-full h-full p-2 overflow-visible"
-            viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
-            preserveAspectRatio="none"
-          >
-            {/* Progress Clipping Mask (Clipped to playhead location) */}
-            <defs>
-              <clipPath id="waveform-progress-clip">
-                <rect
-                  x="0"
-                  y="-10"
-                  width={absolutePlayheadPercent * (SVG_WIDTH / 100)}
-                  height={SVG_HEIGHT + 20}
-                />
-              </clipPath>
-            </defs>
+        {/* Single Layer: Wavesurfer Dual-Wave Rendering & EDL Overlays via SVG */}
+        <svg
+          className="w-full h-full p-3 overflow-visible"
+          viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+          preserveAspectRatio="none"
+        >
+          {/* Progress Clipping Mask (Clipped to playhead location) */}
+          <defs>
+            <clipPath id="waveform-progress-clip">
+              <rect
+                x="0"
+                y="-10"
+                width={absolutePlayheadPercent * (SVG_WIDTH / 100)}
+                height={SVG_HEIGHT + 20}
+              />
+            </clipPath>
+          </defs>
 
-            {/* Group 1: Background Waveform (Unplayed Portion - Muted Violet/Gray) */}
-            <g className="text-primary/20 dark:text-primary/15 transition-all duration-75">
-              {peakStates.map((state, index) => {
-                if (state.isDeleted) {
-                  return (
-                    <rect
-                      key={`bg-del-${index}`}
-                      x={state.x}
-                      y={state.y}
-                      width={state.width}
-                      height={state.height}
-                      rx="1.3"
-                      ry="1.3"
-                      className="fill-muted-foreground/10 dark:fill-muted-foreground/5"
-                    />
-                  );
-                }
-                return (
+          {/* BACKGROUND LAYER: Render soft-green EDL piece blocks behind the waveform peaks */}
+          <g>
+            {pieces.map((piece, i) => {
+              const left = (piece.sourceOffset / totalDuration) * SVG_WIDTH;
+              const width = (piece.length / totalDuration) * SVG_WIDTH;
+              return (
+                <g key={`edl-block-${i}`}>
+                  {/* Soft green block background */}
                   <rect
-                    key={`bg-active-${index}`}
-                    x={state.x}
-                    y={state.y}
-                    width={state.width}
-                    height={state.height}
-                    rx="1.3"
-                    ry="1.3"
-                    fill="currentColor"
+                    x={left}
+                    y={1}
+                    width={width}
+                    height={SVG_HEIGHT - 2}
+                    rx="3"
+                    className="fill-emerald-500/[0.04] dark:fill-emerald-500/[0.06]"
                   />
-                );
-              })}
-            </g>
-
-            {/* Group 2: Foreground Waveform (Played Portion - Clipped to Playhead with vibrant Primary fill) */}
-            <g
-              className="text-primary transition-all duration-75"
-              clipPath="url(#waveform-progress-clip)"
-            >
-              {peakStates.map((state, index) => {
-                // Deleted parts don't light up as played to keep focus on edited state
-                if (state.isDeleted) return null;
-
-                return (
-                  <rect
-                    key={`fg-active-${index}`}
-                    x={state.x}
-                    y={state.y}
-                    width={state.width}
-                    height={state.height}
-                    rx="1.3"
-                    ry="1.3"
-                    fill="currentColor"
-                  />
-                );
-              })}
-            </g>
-
-            {/* Group 3: Strike-through decorations for Deleted Blocks */}
-            <g className="text-muted-foreground/30 dark:text-muted-foreground/20">
-              {peakStates.map((state, index) => {
-                if (!state.isDeleted) return null;
-                
-                // Draw a small cross line in the middle of deleted buckets
-                return (
+                  {/* Subtle boundary tick lines */}
                   <line
-                    key={`strike-${index}`}
-                    x1={state.x - 1}
-                    y1={SVG_HEIGHT / 2}
-                    x2={state.x + state.width + 1}
-                    y2={SVG_HEIGHT / 2}
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeDasharray="1 1"
+                    x1={left}
+                    y1={0}
+                    x2={left}
+                    y2={SVG_HEIGHT}
+                    className="stroke-emerald-500/25 dark:stroke-emerald-400/20"
+                    strokeWidth="1"
+                    strokeDasharray="2 2"
+                  />
+                  <line
+                    x1={left + width}
+                    y1={0}
+                    x2={left + width}
+                    y2={SVG_HEIGHT}
+                    className="stroke-emerald-500/25 dark:stroke-emerald-400/20"
+                    strokeWidth="1"
+                    strokeDasharray="2 2"
+                  />
+                  {/* Subtle Piece label P1, P2 ... in the top left corner of the block */}
+                  {width > 30 && (
+                    <text
+                      x={left + 6}
+                      y={14}
+                      className="fill-emerald-600/40 dark:fill-emerald-400/35 text-[9px] font-mono font-bold tracking-wider"
+                    >
+                      P{i + 1}
+                    </text>
+                  )}
+                </g>
+              );
+            })}
+          </g>
+
+          {/* WAVEFORM LAYER 1: Background Waveform (Unplayed Portion - Muted Violet/Gray) */}
+          <g className="text-primary/20 dark:text-primary/15 transition-all duration-75">
+            {peakStates.map((state, index) => {
+              if (state.isDeleted) {
+                return (
+                  <rect
+                    key={`bg-del-${index}`}
+                    x={state.x}
+                    y={state.y}
+                    width={state.width}
+                    height={state.height}
+                    rx="1.3"
+                    ry="1.3"
+                    className="fill-muted-foreground/10 dark:fill-muted-foreground/5"
                   />
                 );
-              })}
-            </g>
-          </svg>
+              }
+              return (
+                <rect
+                  key={`bg-active-${index}`}
+                  x={state.x}
+                  y={state.y}
+                  width={state.width}
+                  height={state.height}
+                  rx="1.3"
+                  ry="1.3"
+                  fill="currentColor"
+                />
+              );
+            })}
+          </g>
 
-          {/* Wavesurfer Hover Timeline Indicator Line */}
-          {hoverPercent !== null && (
-            <div
-              className="absolute top-0 bottom-0 w-[1.5px] bg-muted-foreground/40 pointer-events-none z-30"
-              style={{ left: `${hoverPercent * 100}%` }}
-            />
-          )}
+          {/* WAVEFORM LAYER 2: Foreground Waveform (Played Portion - Clipped to Playhead with vibrant Primary fill) */}
+          <g
+            className="text-primary transition-all duration-75"
+            clipPath="url(#waveform-progress-clip)"
+          >
+            {peakStates.map((state, index) => {
+              // Deleted parts don't light up as played to keep focus on edited state
+              if (state.isDeleted) return null;
 
-          {/* Wavesurfer Sliding Playhead Indicator Line */}
+              return (
+                <rect
+                  key={`fg-active-${index}`}
+                  x={state.x}
+                  y={state.y}
+                  width={state.width}
+                  height={state.height}
+                  rx="1.3"
+                  ry="1.3"
+                  fill="currentColor"
+                />
+              );
+            })}
+          </g>
+
+          {/* WAVEFORM LAYER 3: Strike-through decorations for Deleted Blocks */}
+          <g className="text-muted-foreground/30 dark:text-muted-foreground/20">
+            {peakStates.map((state, index) => {
+              if (!state.isDeleted) return null;
+              
+              // Draw a small cross line in the middle of deleted buckets
+              return (
+                <line
+                  key={`strike-${index}`}
+                  x1={state.x - 1}
+                  y1={SVG_HEIGHT / 2}
+                  x2={state.x + state.width + 1}
+                  y2={SVG_HEIGHT / 2}
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeDasharray="1 1"
+                />
+              );
+            })}
+          </g>
+        </svg>
+
+        {/* Wavesurfer Hover Timeline Indicator Line */}
+        {hoverPercent !== null && (
           <div
-            className="absolute top-0 bottom-0 w-0.5 bg-primary z-40 pointer-events-none transition-all duration-75 ease-linear shadow-[0_0_10px_rgba(var(--primary-color),0.6)]"
-            style={{ left: `${absolutePlayheadPercent}%` }}
+            className="absolute top-0 bottom-0 w-[1.5px] bg-muted-foreground/40 pointer-events-none z-30"
+            style={{ left: `${hoverPercent * 100}%` }}
           />
-        </div>
+        )}
 
-        {/* Lower Layer: Integrated Piece Table (EDL) Timeline Track */}
-        <div className="h-4 w-full bg-destructive/15 border-t border-border/40 relative flex items-center text-left">
-          {pieces.map((piece, i) => {
-            const leftPercent = (piece.sourceOffset / totalDuration) * 100;
-            const widthPercent = (piece.length / totalDuration) * 100;
-
-            return (
-              <div
-                key={i}
-                className="absolute h-full bg-emerald-500/80 dark:bg-emerald-500/70 border-r border-background/40 last:border-none hover:brightness-110 transition-all flex items-center justify-center overflow-hidden"
-                style={{
-                  left: `${leftPercent}%`,
-                  width: `${widthPercent}%`,
-                }}
-                title={`Piece ${i + 1}\nSource Offset: ${piece.sourceOffset.toFixed(2)}s\nLength: ${piece.length.toFixed(2)}s`}
-              >
-                {widthPercent > 2.5 && (
-                  <span className="text-[9px] font-mono font-bold text-emerald-950 dark:text-emerald-950 px-1 truncate">
-                    P{i + 1}
-                  </span>
-                )}
-              </div>
-            );
-          })}
-        </div>
+        {/* Wavesurfer Sliding Playhead Indicator Line */}
+        <div
+          className="absolute top-0 bottom-0 w-0.5 bg-primary z-40 pointer-events-none transition-all duration-75 ease-linear shadow-[0_0_10px_rgba(var(--primary-color),0.6)]"
+          style={{ left: `${absolutePlayheadPercent}%` }}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
### Summary
This PR implements **Interactive Waveform Visualizations representing the Piece Table EDL** (#18) — the #1 item on TextCast's project roadmap.

### Key Additions
1. **Isolated Downsampling Engine (`src/lib/audio/peaks.ts`)**: Implemented high-performance, stereo-blended min/max peak calculation with optional dynamic decibel/shaping-factor expansion ((x) = x^{\gamma}$). Tested and verified with 100% green unit tests.
2. **Interactive Waveform Component (`src/components/ui/AudioWaveform.tsx`)**:
   * **Visual Sync with Piece Table**: Cross-references peak timestamps with the transcribed words array. Active pieces are rendered in vibrant primary color (with progress overlays), while **deleted words are grayed out / struck-through** on the waveform timeline.
   * **Playhead Mapping**: Seamlessly translates the player's logical playhead time (`currentTime`) to the absolute original timeline position. As the editor skips deleted words, the playhead visually **snaps and jumps** across deleted sections.
   * **Click-to-Seek Mapping**: Clicking any column translates absolute horizontal coordinates back to logical player time (or snaps to the nearest active piece boundary if clicking a deleted zone) and seeks the player.
3. **Seamless Integration (`src/components/editor/TranscriptEditor.tsx`)**: Swapped out the basic progress bar line for this interactive waveform.

### Verification
* All **30/30 unit tests passed** successfully.
* Production build checks compile cleanly with zero errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the progress bar with an interactive audio waveform showing the signal and playback position.
  * Click-to-seek on the waveform (clicks snap to nearest active segment when needed) and hover shows a “seek to” time indicator.
  * Visual distinction for edited/deleted regions and a played-overlay with playhead indicator.
  * Shows a placeholder when no audio is available.
  * Transcript status now displays the count of active pieces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sirmews/textcast/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->